### PR TITLE
CI: build bats from C artifact

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,48 @@
+name: check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ATS2
+        run: |
+          curl -sL "https://raw.githubusercontent.com/ats-lang/ats-lang.github.io/master/FROZEN000/ATS-Postiats/ATS2-Postiats-int-0.4.2.tgz" -o /tmp/ats2.tgz
+          mkdir -p ~/.ats2
+          tar -xzf /tmp/ats2.tgz -C ~/.ats2
+          cd ~/.ats2/ATS2-Postiats-int-0.4.2
+          make -j$(nproc) -C src/CBOOT patsopt
+          mkdir -p bin
+          cp src/CBOOT/patsopt bin/patsopt
+
+      - name: Cache bats compiler
+        id: cache-bats
+        uses: actions/cache@v4
+        with:
+          path: ~/bats-bin
+          key: bats-from-c-${{ runner.os }}-${{ hashFiles('.github/workflows/check.yml') }}
+
+      - name: Build bats from C
+        if: steps.cache-bats.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RUN_ID=$(gh run list --repo bats-lang/bats --branch main --status success --workflow check --limit 1 --json databaseId --jq '.[0].databaseId')
+          gh run download "$RUN_ID" --repo bats-lang/bats --name bats-c --dir ~/bats-c
+          cd ~/bats-c
+          make PATSHOME=$HOME/.ats2/ATS2-Postiats-int-0.4.2
+          mkdir -p ~/bats-bin
+          cp debug/bats ~/bats-bin/bats
+
+      - name: bats check
+        run: |
+          git clone https://github.com/bats-lang/repository-prototype.git ~/repository
+          ~/bats-bin/bats lock --repository ~/repository
+          ~/bats-bin/bats check --repository ~/repository


### PR DESCRIPTION
Switch CI to download the bats-c artifact and build with make instead of cargo.